### PR TITLE
Uses the latest "lists for" endpoint

### DIFF
--- a/lib/for.js
+++ b/lib/for.js
@@ -16,5 +16,5 @@ module.exports = (listType, conceptID, options, timeout) => {
 		return Promise.reject(new TypeError(`Unknown list type "${listType}"`));
 	}
 
-	return fetchList(`lists?curated${listType}For=${conceptID}`, options, timeout);
+	return fetchList(`lists?listType=${listType}&conceptUUID=${conceptID}`, options, timeout);
 };

--- a/test/spec/for-spec.js
+++ b/test/spec/for-spec.js
@@ -35,7 +35,7 @@ describe('lib/for', () => {
 		subject('TopStories', 123).then(() => {
 			sinon.assert.calledWith(
 				stubs.fetchList,
-				'lists?curatedTopStoriesFor=123'
+				'lists?listType=TopStories&conceptUUID=123'
 			);
 		})
 	));


### PR DESCRIPTION
I have spoken to engineers in the Core team and they mentioned that this
endpoint we were using is old and not their preferred route for this
api.

They believe that once FT.com stops using it they might be able to
remove it, this is a step towards that.