### PR TITLE
Add node-fetch

### DIFF
--- a/lib/helpers/fetch-capi.js
+++ b/lib/helpers/fetch-capi.js
@@ -1,3 +1,5 @@
+const fetch = require('node-fetch');
+
 const handleResponse = require('./handle-response');
 
 module.exports = (endpoint, timeout) => (

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@financial-times/n-es-client": "^1.6.1",
     "@financial-times/n-logger": "^6.0.0",
-    "http-errors": "^1.6.2"
+    "http-errors": "^1.6.2",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^5.1.2",


### PR DESCRIPTION
[CI workflow tests](https://app.circleci.com/pipelines/github/Financial-Times/n-lists-client/405/workflows/68f6aea1-adb6-4623-a6b3-dc0970690ced/jobs/2136) for this repo are failing owing to: `ReferenceError: fetch is not defined`.

This package will be used server-side so we need not worry about fetch being applied server-side (and needing something like `isomorphic-fetch`), so `node-fetch` should do just fine.

### New dependencies:
- [npm: `node-fetch`](https://www.npmjs.com/package/node-fetch)