### PR TITLE
Upgrade n-es-client ^1.6.1 -> 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-lists-client",
   "dependencies": {
-    "@financial-times/n-es-client": "^1.6.1",
+    "@financial-times/n-es-client": "3.0.0",
     "@financial-times/n-logger": "^6.0.0",
     "http-errors": "^1.6.2",
     "node-fetch": "^2.6.1"


### PR DESCRIPTION
This PR upgrades the version of `n-es-client` to v3.0.0 so that all of its Elasticsearch requests are directed to the new Elasticsearch v7 cluster.

The only requests this package uses `n-es-client` uses to make are `mget` requests, and the arguments being used here remain unchanged between Elasticsearch v5 and v7.