### PR TITLE
To get instrumentation data, use global.fetch (when available)

### DIFF
--- a/lib/helpers/fetch-capi.js
+++ b/lib/helpers/fetch-capi.js
@@ -1,13 +1,21 @@
 const fetch = require('node-fetch');
+const logger = require('@financial-times/n-logger').default;
 
 const handleResponse = require('./handle-response');
 
-module.exports = (endpoint, timeout) => (
-	(global.fetch || fetch)('https://api.ft.com/' + endpoint, {
+module.exports = (endpoint, timeout) => {
+	const url = `https://api.ft.com/${endpoint}`;
+	return (global.fetch || fetch)(url, {
 		headers: {
 			'X-API-Key': process.env.API_KEY
 		},
 		timeout
-	})
-		.then(handleResponse)
-);
+	}).then(handleResponse, (error) => {
+		logger.warn({
+			event: 'LISTS_FETCH_FAILED',
+			error: error.name,
+			url,
+		});
+		throw error;
+	});
+};

--- a/lib/helpers/fetch-capi.js
+++ b/lib/helpers/fetch-capi.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 const handleResponse = require('./handle-response');
 
 module.exports = (endpoint, timeout) => (
-	fetch('https://api.ft.com/' + endpoint, {
+	(global.fetch || fetch)('https://api.ft.com/' + endpoint, {
 		headers: {
 			'X-API-Key': process.env.API_KEY
 		},

--- a/lib/helpers/handle-response.js
+++ b/lib/helpers/handle-response.js
@@ -5,11 +5,21 @@ module.exports = (response) => {
 	if (response.ok) {
 		return response.json();
 	} else {
-		logger.warn({
-			event: 'LISTS_CLIENT_FAILED',
-			statusCode: response.status,
-			statusText: response.statusText,
-		});
+		if (response.status === 404) {
+			logger.info({
+				event: 'LIST_NOT_FOUND',
+				url: response.url,
+				uuid: response.url.toString().split('/').pop(),
+			});
+		} else {
+			logger.warn({
+				event: 'LISTS_CLIENT_FAILED',
+				url: response.url,
+				uuid: response.url.toString().split('/').pop(),
+				statusCode: response.status,
+				statusText: response.statusText,
+			});
+		}
 
 		return response.text()
 			.then((text) => {

--- a/test/spec/for-spec.js
+++ b/test/spec/for-spec.js
@@ -2,7 +2,7 @@ const proxyquire = require('proxyquire');
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const sandbox = sinon.sandbox.create();
+const sandbox = sinon.createSandbox();
 
 const stubs = {
 	fetchList: sandbox.stub()

--- a/test/spec/get-spec.js
+++ b/test/spec/get-spec.js
@@ -2,7 +2,7 @@ const proxyquire = require('proxyquire');
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const sandbox = sinon.sandbox.create();
+const sandbox = sinon.createSandbox();
 
 const stubs = {
 	fetchList: sandbox.stub()

--- a/test/spec/helpers/fetch-capi-spec.js
+++ b/test/spec/helpers/fetch-capi-spec.js
@@ -1,0 +1,72 @@
+const proxyquire = require('proxyquire');
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const stubs = {
+	nodeFetch: sinon.stub(),
+	globalFetch: sinon.stub(),
+};
+
+const fakeAPIKey = 'FAKE_KEY';
+
+const response = (value) => ({
+	ok: true,
+	json: () => Promise.resolve(value)
+});
+
+const subject = proxyquire('../../../lib/helpers/fetch-capi', {
+	'node-fetch': stubs.nodeFetch
+});
+
+describe('lib/helpers/fetch-list', () => {
+
+	beforeEach(() => {
+		stubs.nodeFetch.reset();
+		stubs.globalFetch.reset();
+		global.fetch = undefined;
+		process.env.API_KEY = fakeAPIKey;
+		stubs.nodeFetch.resolves(response({}));
+		stubs.globalFetch.resolves(response({}));
+	});
+
+	afterEach(() => {
+		process.env.API_KEY = undefined;
+	});
+
+	it('It builds a CAPI URL', () => {
+		const url = 'test-url';
+		return subject(url).then(() => {
+			expect(stubs.nodeFetch.getCall(0).args[0]).to.equal(`https://api.ft.com/${url}`);
+		});
+	});
+
+	it('It sets the "X-API-Key" request header', () => {
+		return subject('test-url').then(() => {
+			expect(stubs.nodeFetch.getCall(0).args[1]).to.deep.include({headers: {'X-API-Key': fakeAPIKey}});
+		});
+	});
+
+	it('It uses the specified timeout value', () => {
+		const timeout = 1000;
+		return subject('test-url', timeout).then(() => {
+			expect(stubs.nodeFetch.getCall(0).args[1]).to.deep.include({timeout});
+		});
+	});
+
+	it('use node-fetch when global fetch is not defined', () => {
+		return subject('test-url').then(() => {
+			sinon.assert.calledOnce(stubs.nodeFetch);
+			sinon.assert.notCalled(stubs.globalFetch);
+			expect(stubs.nodeFetch.getCall(0).args[0]).to.include('test-url');
+		});
+	});
+
+	it('use global.fetch when it is defined', () => {
+		global.fetch = stubs.globalFetch;
+		return subject('test-url').then(() => {
+			sinon.assert.calledOnce(stubs.globalFetch);
+			sinon.assert.notCalled(stubs.nodeFetch);
+			expect(stubs.globalFetch.getCall(0).args[0]).to.include('test-url');
+		});
+	});
+});

--- a/test/spec/helpers/fetch-list-spec.js
+++ b/test/spec/helpers/fetch-list-spec.js
@@ -6,7 +6,7 @@ const nock = require('nock');
 const fixtureLists = require('../../fixtures/list-found.json');
 const fixtureContent = require('../../fixtures/elastic-mget.json');
 
-const sandbox = sinon.sandbox.create();
+const sandbox = sinon.createSandbox();
 
 const stubs = {
 	client: {


### PR DESCRIPTION
We have a gap in our Lists API instrumentation data. Most of our apps have the global fetch wrapped with next-metrics instrumentation. This library doesn't use that.

I've also improved the logging: Timeouts are now logged (they weren't before) and the log level of 404-NotFound errors is Info (because we generate a lot of logging data in Splunk for info we don't need).

I've also added some missing tests.