### PR TITLE
Add LISTS_CLIENT_FAILED logs for n-es-client errors

### DIFF
--- a/lib/helpers/fetch-list.js
+++ b/lib/helpers/fetch-list.js
@@ -1,10 +1,26 @@
 const client = require('@financial-times/n-es-client');
 const fetchCAPI = require('./fetch-capi');
 const formatID = require('./format-id');
+const logger = require('@financial-times/n-logger').default;
 
 const DEFAULTS = {
 	fields: [ 'id', 'url', 'title', 'publishedDate' ]
 };
+
+const fetchESMget = async (endpoint, docs, timeout) => {
+	try {
+		return 	await client.mget({ docs }, timeout);
+	} catch (error) {
+		logger.warn({
+			event: 'LISTS_CLIENT_FAILED',
+			url: endpoint,
+			uuid: formatID(endpoint),
+			name: error.name,
+			message: error.message,
+		});
+		throw error;
+	}
+}
 
 async function fetchList (endpoint, options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
@@ -19,8 +35,7 @@ async function fetchList (endpoint, options = {}, timeout = 3000) {
 		_source: params.fields
 	}));
 
-	const contentItems = await client.mget({ docs }, timeout);
-
+	const contentItems = await fetchESMget(endpoint, docs, timeout);
 	// n-es-client will filter out any items not found.
 	return Object.assign(listData, { items: contentItems });
 }


### PR DESCRIPTION
For CAPI api, it logs `LISTS_CLIENT_FAILED` event ([here](https://github.com/Financial-Times/n-lists-client/blob/main/lib/helpers/fetch-capi.js#L25-L31)) however no error logs for n-es-client.

In consumer Apps, the logs are unhelpful ([The splunk log](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3Dheroku%20source%3D%22*next-stream-page*%22%20%22mget%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1658744980.81&latest=1658744990.811&sid=1659353091.778836))

![Screenshot 2022-08-01 at 12 29 56](https://user-images.githubusercontent.com/21194161/182139010-061e566c-cddb-4852-a9b4-14510b9840cd.png)

We can check whether the elasticsearch errors come from n-lists-client or not with more detail by adding this logs.

<img width="836" alt="Screenshot 2022-08-01 at 12 40 37" src="https://user-images.githubusercontent.com/21194161/182140350-3f8c6f47-56a4-49f1-b799-197fbea68e55.png">
