### PR TITLE
Replace n-logger with dotcom-reliability-kit loggr

### DIFF
--- a/lib/helpers/fetch-capi.js
+++ b/lib/helpers/fetch-capi.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch');
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger').default;
 const httpError = require('http-errors');
 const formatID = require('./format-id');
 

--- a/lib/helpers/fetch-list.js
+++ b/lib/helpers/fetch-list.js
@@ -1,7 +1,7 @@
 const client = require('@financial-times/n-es-client');
 const fetchCAPI = require('./fetch-capi');
 const formatID = require('./format-id');
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger').default;
 
 const DEFAULTS = {
 	fields: [ 'id', 'url', 'title', 'publishedDate' ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@financial-times/n-lists-client",
       "version": "0.0.0",
       "dependencies": {
+        "@dotcom-reliability-kit/logger": "^2.2.2",
         "@financial-times/n-es-client": "3.0.2",
-        "@financial-times/n-logger": "^10.0.0",
         "http-errors": "^1.6.2",
         "node-fetch": "^2.6.1"
       },
@@ -336,6 +336,42 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/logger": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.2.tgz",
+      "integrity": "sha512-TjUIkICyizD9jJ6BLHL4o02N2tvibRXYrs3lya6UOsALFl0xHEiyRCPyoqEYRkpW9huvIZy0jL4z0+EpcpeaiA==",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "pino": "^8.12.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "pino-pretty": ">=7.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
     "node_modules/@financial-times/eslint-config-next": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
@@ -426,21 +462,6 @@
       },
       "bin": {
         "ngage": "scripts/ngage.js"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-logger": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.0.0.tgz",
-      "integrity": "sha512-i6I0Yop/wnAv5ZyJ9hdN3ldeXiBfgZanwYTn5HiNY7ccCAZBDvmc0FFqAh3fCIlN7b7DOo4+vRKirZCe/110SA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
       },
       "engines": {
         "node": "14.x || 16.x",
@@ -640,6 +661,22 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "6.4.2",
       "dev": true,
@@ -798,6 +835,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -844,8 +889,26 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -915,6 +978,29 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -1216,6 +1302,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "peer": true
+    },
     "node_modules/colors": {
       "version": "1.3.3",
       "dev": true,
@@ -1381,6 +1473,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1658,7 +1759,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -1957,6 +2057,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "1.0.0",
       "dev": true,
@@ -2018,6 +2134,12 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "peer": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -2048,6 +2170,20 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "peer": true
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -2171,7 +2307,6 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
@@ -2504,6 +2639,56 @@
         "he": "bin/he"
       }
     },
+    "node_modules/help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "peer": true,
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/help-me/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/help-me/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "dev": true,
@@ -2612,6 +2797,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "dev": true,
@@ -2662,7 +2866,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -3150,6 +3353,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -3698,7 +3910,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/minimist-options": {
@@ -7683,9 +7894,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7913,6 +8128,107 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.1.tgz",
+      "integrity": "sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.0.tgz",
+      "integrity": "sha512-zKFjYXBzLaLTEAN1ayKpHXtL5UeRQC7R3lvhKe7fWs7hIVEjKGG/qIXwQt9HmeUp71ogUd/YcW+LmMwRp4KT6Q==",
+      "peer": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.1.tgz",
+      "integrity": "sha512-wHuWB+CvSVb2XqXM0W/WOYUkVSPbiJb9S5fNB7TBhd8s892Xq910bRxwHtC4l71hgztObTjXL6ZheZXFjhDrDQ=="
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -8077,6 +8393,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -8135,7 +8464,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -8183,6 +8511,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "1.1.0",
@@ -8327,7 +8660,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8335,6 +8667,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -8610,7 +8950,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8627,6 +8966,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -8635,6 +8982,12 @@
       "version": "1.3.0",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -8760,6 +9113,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8804,6 +9165,14 @@
       "dev": true,
       "bin": {
         "specificity": "bin/specificity"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8853,7 +9222,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -9684,6 +10052,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+      "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "dev": true,
@@ -9915,8 +10291,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -10153,7 +10528,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write": {
@@ -10523,6 +10897,27 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
+    },
+    "@dotcom-reliability-kit/logger": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.2.tgz",
+      "integrity": "sha512-TjUIkICyizD9jJ6BLHL4o02N2tvibRXYrs3lya6UOsALFl0xHEiyRCPyoqEYRkpW9huvIZy0jL4z0+EpcpeaiA==",
+      "requires": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "pino": "^8.12.1"
+      }
+    },
+    "@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+    },
     "@financial-times/eslint-config-next": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
@@ -10601,16 +10996,6 @@
         "stylelint-order": "^4.1.0",
         "stylelint-scss": "^3.18.0",
         "yargs": "^16.0.0"
-      }
-    },
-    "@financial-times/n-logger": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.0.0.tgz",
-      "integrity": "sha512-i6I0Yop/wnAv5ZyJ9hdN3ldeXiBfgZanwYTn5HiNY7ccCAZBDvmc0FFqAh3fCIlN7b7DOo4+vRKirZCe/110SA==",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
       }
     },
     "@financial-times/n-pa11y-config": {
@@ -10765,6 +11150,19 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "6.4.2",
       "dev": true
@@ -10861,6 +11259,11 @@
       "version": "0.4.0",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -10890,8 +11293,12 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -10940,6 +11347,15 @@
           "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
           "dev": true
         }
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "call-bind": {
@@ -11148,6 +11564,12 @@
       "version": "1.1.3",
       "dev": true
     },
+    "colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "peer": true
+    },
     "colors": {
       "version": "1.3.3",
       "dev": true
@@ -11263,6 +11685,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "peer": true
     },
     "debug": {
       "version": "4.3.4",
@@ -11463,7 +11891,6 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -11670,6 +12097,16 @@
       "version": "2.0.3",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "execa": {
       "version": "1.0.0",
       "dev": true,
@@ -11712,6 +12149,12 @@
     "eyes": {
       "version": "0.1.8"
     },
+    "fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "peer": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -11736,6 +12179,17 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
+    },
+    "fast-redact": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "peer": true
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -11824,8 +12278,7 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "function-bind": {
       "version": "1.1.1",
@@ -12035,6 +12488,49 @@
       "version": "1.1.1",
       "dev": true
     },
+    "help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "peer": true,
+      "requires": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "dev": true
@@ -12108,6 +12604,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "dev": true
@@ -12136,7 +12637,6 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12430,6 +12930,12 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
+    },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -12808,8 +13314,7 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "dev": true
+      "version": "1.2.6"
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -15690,9 +16195,13 @@
         "object-keys": "^1.1.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "once": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15841,6 +16350,93 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pino": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.1.tgz",
+      "integrity": "sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+          "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
+    "pino-pretty": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.0.tgz",
+      "integrity": "sha512-zKFjYXBzLaLTEAN1ayKpHXtL5UeRQC7R3lvhKe7fWs7hIVEjKGG/qIXwQt9HmeUp71ogUd/YcW+LmMwRp4KT6Q==",
+      "peer": true,
+      "requires": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+          "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "peer": true
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.1.tgz",
+      "integrity": "sha512-wHuWB+CvSVb2XqXM0W/WOYUkVSPbiJb9S5fNB7TBhd8s892Xq910bRxwHtC4l71hgztObTjXL6ZheZXFjhDrDQ=="
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -15968,6 +16564,16 @@
       "version": "1.1.2",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
+    "process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+    },
     "progress": {
       "version": "2.0.3",
       "dev": true
@@ -16008,7 +16614,6 @@
     },
     "pump": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -16030,6 +16635,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -16127,12 +16737,16 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "redent": {
       "version": "2.0.0",
@@ -16306,8 +16920,12 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "dev": true
+      "version": "5.2.1"
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "safer-buffer": {
       "version": "2.1.2"
@@ -16315,6 +16933,12 @@
     "samsam": {
       "version": "1.3.0",
       "dev": true
+    },
+    "secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "peer": true
     },
     "semver": {
       "version": "5.7.1",
@@ -16402,6 +17026,14 @@
       "version": "1.899.0",
       "dev": true
     },
+    "sonic-boom": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -16438,6 +17070,11 @@
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "dev": true
@@ -16467,7 +17104,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -17066,6 +17702,14 @@
       "version": "0.2.0",
       "dev": true
     },
+    "thread-stream": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+      "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "dev": true
@@ -17225,8 +17869,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",
@@ -17399,8 +18042,7 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/Financial-Times/n-lists-client",
   "dependencies": {
+    "@dotcom-reliability-kit/logger": "^2.2.2",
     "@financial-times/n-es-client": "3.0.2",
-    "@financial-times/n-logger": "^10.0.0",
     "http-errors": "^1.6.2",
     "node-fetch": "^2.6.1"
   },

--- a/test/spec/helpers/fetch-capi-spec.js
+++ b/test/spec/helpers/fetch-capi-spec.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const stubs = {
 	nodeFetch: sinon.stub(),
 	globalFetch: sinon.stub(),
-	nLogger: {
+	logger: {
 		warn: sinon.stub(),
 		info: sinon.stub(),
 	}
@@ -22,8 +22,8 @@ const response = (value) => ({
 
 const subject = proxyquire('../../../lib/helpers/fetch-capi', {
 	'node-fetch': stubs.nodeFetch,
-	'@financial-times/n-logger': {
-		default: stubs.nLogger,
+	'@dotcom-reliability-kit/logger': {
+		default: stubs.logger,
 	},
 });
 
@@ -32,8 +32,8 @@ describe('lib/helpers/fetch-capi', () => {
 	beforeEach(() => {
 		stubs.nodeFetch.reset();
 		stubs.globalFetch.reset();
-		stubs.nLogger.warn.reset();
-		stubs.nLogger.info.reset();
+		stubs.logger.warn.reset();
+		stubs.logger.info.reset();
 		global.fetch = undefined;
 		process.env.API_KEY = fakeAPIKey;
 		stubs.nodeFetch.resolves(response({}));
@@ -113,8 +113,8 @@ describe('lib/helpers/fetch-capi', () => {
 		it('logs the error with WARN level', () => {
 			return subject(url).catch(() => {
 				sinon.assert.calledOnce(stubs.nodeFetch);
-				sinon.assert.calledOnce(stubs.nLogger.warn);
-				expect(stubs.nLogger.warn.getCall(0).args[0]).to.deep.include({
+				sinon.assert.calledOnce(stubs.logger.warn);
+				expect(stubs.logger.warn.getCall(0).args[0]).to.deep.include({
 					statusCode: status,
 					url: `https://api.ft.com/${url}`,
 					uuid: listUUID,
@@ -156,8 +156,8 @@ describe('lib/helpers/fetch-capi', () => {
 		it('logs the error with INFO level', () => {
 			return subject(url).catch(() => {
 				sinon.assert.calledOnce(stubs.nodeFetch);
-				sinon.assert.calledOnce(stubs.nLogger.info);
-				expect(stubs.nLogger.info.getCall(0).args[0]).to.deep.include({
+				sinon.assert.calledOnce(stubs.logger.info);
+				expect(stubs.logger.info.getCall(0).args[0]).to.deep.include({
 					url: `https://api.ft.com/${url}`,
 					uuid: listUUID,
 				});


### PR DESCRIPTION
# what is this about

[Jira ticket](https://financialtimes.atlassian.net/browse/CON-2562): 
we are updating some stuff everywhere following this [migration guide](https://docs.google.com/document/d/1BkXL-DQ4Mni_WtMGiwhWyXAChNCYR1Wav26ogcE0oJw/edit#heading=h.nc8rr6a11gem). This package only needed those 2 updates: 
- **Removing n-logger (what we are doing here)**
- Dropping support to node 14 (PR to follow)

# What did I do ? 

- Replace the old logger with the dotcom-reliability (in the code and in the tests)
- Renamed `nLogger` to `logger` in the test 
- Look for the format of the error and did not find any mention of the old error (for example `error_name`) 
- Look for the 'time' property in the code and did not find it
- Look for 'weird log level' and did not find any
- Look for `AddContext` method and did not find it
- There doesn't seem to be a proxy in contact with the logger

# How did I test

- I ran the unit tests `make unit-test`
- Npm linked **n-lists-client** to **next-stream-page** and made sure that the new logs got logged in the console without any issue (added some property to make sure the npm linking was working and the log I was seeing was the good one)

![Screenshot 2023-06-09 at 17 04 40 (3)](https://github.com/Financial-Times/n-lists-client/assets/107469842/4b696a0b-3613-4071-b94c-0385afe2145c)

_Legend: the new log being logged_

![Screenshot 2023-06-09 at 17 04 46 (3)](https://github.com/Financial-Times/n-lists-client/assets/107469842/eda41580-83c2-403e-9ba5-7c903b3fd382) 

_Legend: The log modification to show that it's the new log that is properly linked and logged_

_Don't pay attention to the error in that console, I was just unsure if I needed to `npm start` the app after linking it, and turns out I dont and there isn't a `npm start` script for this app_

NB: why is **next-stream-page** getting some logs by the way 😱 ?   

In **next-stream-page** [runbook](https://github.com/Financial-Times/next-stream-page/blob/main/runbook.md#second-line-troubleshooting) we can read the following:   
"You may find a lot of n-lists-client 404 errors in Splunk logs (when the SPLUNK_LOG_LEVEL is set to info). Usually, they are expected responses from n-lists-client. The 404s are thrown when stream pages try to fetch lists that haven’t been curated with their stream page id(= concept id). It seems that happens often with stream pages that aren't specified in [config/profiles.js file](https://github.com/Financial-Times/next-stream-page/blob/main/server/config/profiles.js), that is the vast majority of stream pages. defaultTransformsFull function is used for those pages. It makes requests for top stories list, opinion analysis list and recommended list even if the page doesn't have those correlated lists, hence producing the 404 errors." 

# Next 

Will remove `SPLUNK_HEC_TOKEN` from Vault using cp_vault_interface once the migration is done. 
