### PR TITLE
[CON-2713] Migrate to node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,59 +2,50 @@
 # template: component
 
 references:
-  container_config_node:
-    &container_config_node
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:<< parameters.node-version >>
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys:
-    &npm_cache_keys
+  npm_cache_keys: &npm_cache_keys
     keys:
       - v2-dependency-npm-{{ checksum "package-lock.json" }}-
       - v2-dependency-npm-{{ checksum "package-lock.json" }}
       - v2-dependency-npm-
 
-  cache_npm_cache:
-    &cache_npm_cache
+  cache_npm_cache: &cache_npm_cache
     save_cache:
       key: v2-dependency-npm-{{ checksum "package-lock.json" }}-{{ epoch }}
       paths:
         - ./node_modules/
 
-  restore_npm_cache:
-    &restore_npm_cache
+  restore_npm_cache: &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main:
-    &filters_only_main
+  filters_only_main: &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main:
-    &filters_ignore_main
+  filters_ignore_main: &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags:
-    &filters_ignore_tags
+  filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag:
-    &filters_version_tag
+  filters_version_tag: &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -71,8 +62,8 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - run:
           name: Install project dependencies
@@ -139,14 +130,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   build-test-publish:
     jobs:
@@ -156,7 +147,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -165,13 +156,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.16
 
   nightly:
     triggers:
@@ -185,7 +176,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -193,7 +184,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
 notify:
   webhooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
-        "@financial-times/n-gage": "^9.0.0",
+        "@financial-times/n-gage": "^9.0.1",
         "chai": "^4.1.0",
         "coveralls": "^3.0.0",
         "mocha": "^5.2.0",
@@ -25,7 +25,8 @@
         "snyk": "^1.167.2"
       },
       "engines": {
-        "node": "16.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -439,9 +440,9 @@
       }
     },
     "node_modules/@financial-times/n-gage": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-gage/-/n-gage-9.0.0.tgz",
-      "integrity": "sha512-l18LyuIHRjzzT48Fav+cUKh0bkdOMceepJuY0UtwqXTrA9LMBdTAIE+3hIn2DYctPFFUF7PNO4k9TIJQeA6BtA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-gage/-/n-gage-9.0.1.tgz",
+      "integrity": "sha512-COrE7UkxaVs3VoGp8UPMBdYDj3inxAozpSFbUJr26dVXUJauCdDP0RqdfHRAv83ROl3X4B/G1x6ycXWmD6RfIA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10977,9 +10978,9 @@
       }
     },
     "@financial-times/n-gage": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-gage/-/n-gage-9.0.0.tgz",
-      "integrity": "sha512-l18LyuIHRjzzT48Fav+cUKh0bkdOMceepJuY0UtwqXTrA9LMBdTAIE+3hIn2DYctPFFUF7PNO4k9TIJQeA6BtA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-gage/-/n-gage-9.0.1.tgz",
+      "integrity": "sha512-COrE7UkxaVs3VoGp8UPMBdYDj3inxAozpSFbUJr26dVXUJauCdDP0RqdfHRAv83ROl3X4B/G1x6ycXWmD6RfIA==",
       "dev": true,
       "requires": {
         "@financial-times/eslint-config-next": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^9.0.0",
+    "@financial-times/n-gage": "^9.0.1",
     "chai": "^4.1.0",
     "coveralls": "^3.0.0",
     "mocha": "^5.2.0",
@@ -26,7 +26,8 @@
     "snyk": "^1.167.2"
   },
   "engines": {
-    "node": "16.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "scripts": {
     "prepare": "npx snyk protect || npx snyk protect -d || true"
@@ -39,6 +40,6 @@
     }
   },
   "volta": {
-    "node": "16.14.2"
+    "node": "18.16.1"
   }
 }


### PR DESCRIPTION
**Description**

PR to achieve upgrade to Node 18v. This is part of [migrating to Node v. 18 Initiative](https://financialtimes.atlassian.net/browse/CON-2706).

In order to achieve the migration, it has been used the following [migration script](https://github.com/Financial-Times/platform-scripts/tree/7c571c9e8e5e452e6cf16f36fc44b0769c71551f/upgrade-node-18).