### PR TITLE
Update dependencies to use Reliability Kit logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@financial-times/n-lists-client",
       "version": "0.0.0",
       "dependencies": {
-        "@dotcom-reliability-kit/logger": "^2.2.2",
-        "@financial-times/n-es-client": "3.0.2",
+        "@dotcom-reliability-kit/logger": "^2.2.7",
+        "@financial-times/n-es-client": "^5.0.0",
         "http-errors": "^1.6.2",
         "node-fetch": "^2.6.1"
       },
@@ -347,14 +347,14 @@
       }
     },
     "node_modules/@dotcom-reliability-kit/logger": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.2.tgz",
-      "integrity": "sha512-TjUIkICyizD9jJ6BLHL4o02N2tvibRXYrs3lya6UOsALFl0xHEiyRCPyoqEYRkpW9huvIZy0jL4z0+EpcpeaiA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.7.tgz",
+      "integrity": "sha512-XTvGwaki9BOTiCVD/ti3IWMTEKKbmRjp3TgM48HYSb7qG3CThW2alqtuB51rDWdlVv3c6OFnXhURCX9tHyuhdQ==",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-        "@ungap/structured-clone": "^1.2.0",
-        "pino": "^8.12.1"
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.14.1"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -384,27 +384,18 @@
       }
     },
     "node_modules/@financial-times/n-es-client": {
-      "version": "3.0.2",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-es-client/-/n-es-client-5.0.0.tgz",
+      "integrity": "sha512-SNbRQIbISJVK25Gblj659L8xCaoap4PNR3SE18vCtCCLYLfmUeNaAk4/JlwEna9SylbwRGLADrwpNIWk69m1mA==",
+      "hasInstallScript": true,
       "dependencies": {
-        "@financial-times/n-logger": "^6.0.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "http-errors": "^1.8.0",
         "signed-aws-es-fetch": "^1.4.0"
       },
       "engines": {
-        "node": "12.x"
-      }
-    },
-    "node_modules/@financial-times/n-es-client/node_modules/@financial-times/n-logger": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-      "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=6.1.0"
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-fetch": {
@@ -662,11 +653,6 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -829,6 +815,7 @@
     },
     "node_modules/async": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -1461,6 +1448,7 @@
     },
     "node_modules/cycle": {
       "version": "1.0.3",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2115,6 +2103,7 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
+      "dev": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -3318,6 +3307,7 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/iterate-iterator": {
@@ -3410,6 +3400,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -3562,6 +3553,11 @@
       "version": "4.17.21",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -9136,6 +9132,7 @@
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -10334,6 +10331,7 @@
     },
     "node_modules/winston": {
       "version": "2.4.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "~1.0.0",
@@ -10349,6 +10347,7 @@
     },
     "node_modules/winston/node_modules/colors": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
@@ -10833,14 +10832,14 @@
       "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
     },
     "@dotcom-reliability-kit/logger": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.2.tgz",
-      "integrity": "sha512-TjUIkICyizD9jJ6BLHL4o02N2tvibRXYrs3lya6UOsALFl0xHEiyRCPyoqEYRkpW9huvIZy0jL4z0+EpcpeaiA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.7.tgz",
+      "integrity": "sha512-XTvGwaki9BOTiCVD/ti3IWMTEKKbmRjp3TgM48HYSb7qG3CThW2alqtuB51rDWdlVv3c6OFnXhURCX9tHyuhdQ==",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-        "@ungap/structured-clone": "^1.2.0",
-        "pino": "^8.12.1"
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.14.1"
       }
     },
     "@dotcom-reliability-kit/serialize-error": {
@@ -10859,23 +10858,13 @@
       }
     },
     "@financial-times/n-es-client": {
-      "version": "3.0.2",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-es-client/-/n-es-client-5.0.0.tgz",
+      "integrity": "sha512-SNbRQIbISJVK25Gblj659L8xCaoap4PNR3SE18vCtCCLYLfmUeNaAk4/JlwEna9SylbwRGLADrwpNIWk69m1mA==",
       "requires": {
-        "@financial-times/n-logger": "^6.0.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "http-errors": "^1.8.0",
         "signed-aws-es-fetch": "^1.4.0"
-      },
-      "dependencies": {
-        "@financial-times/n-logger": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-          "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "node-fetch": "^2.6.0",
-            "winston": "^2.4.0"
-          }
-        }
       }
     },
     "@financial-times/n-fetch": {
@@ -11080,11 +11069,6 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
-    "@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -11183,7 +11167,8 @@
       "dev": true
     },
     "async": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -11607,7 +11592,8 @@
       }
     },
     "cycle": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -12065,7 +12051,8 @@
       "dev": true
     },
     "eyes": {
-      "version": "0.1.8"
+      "version": "0.1.8",
+      "dev": true
     },
     "fast-copy": {
       "version": "3.0.1",
@@ -12835,7 +12822,8 @@
       }
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "iterate-iterator": {
       "version": "1.0.2",
@@ -12898,7 +12886,8 @@
       "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "json5": {
       "version": "2.2.1",
@@ -13002,6 +12991,11 @@
     "lodash": {
       "version": "4.17.21",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -16980,7 +16974,8 @@
       }
     },
     "stack-trace": {
-      "version": "0.0.10"
+      "version": "0.0.10",
+      "dev": true
     },
     "statuses": {
       "version": "1.5.0"
@@ -17839,6 +17834,7 @@
     },
     "winston": {
       "version": "2.4.5",
+      "dev": true,
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -17849,7 +17845,8 @@
       },
       "dependencies": {
         "colors": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "homepage": "https://github.com/Financial-Times/n-lists-client",
   "dependencies": {
-    "@dotcom-reliability-kit/logger": "^2.2.2",
-    "@financial-times/n-es-client": "3.0.2",
+    "@dotcom-reliability-kit/logger": "^2.2.7",
+    "@financial-times/n-es-client": "^5.0.0",
     "http-errors": "^1.6.2",
     "node-fetch": "^2.6.1"
   },


### PR DESCRIPTION
This ensures that all the dependencies of this module are using Reliability Kit logger. As you already released the major version for Reliability Kit logger we don't need to release another major for this.

The n-es-client upgrade should be safe to do:

  - v4.0.0 drops Node.js 14 support, which this module already has
  - v5.0.0 migrates to Reliability Kit logger